### PR TITLE
Update GitHub actions to fix deprecation warnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,8 +23,8 @@ jobs:
           - '3.9'
           - '3.10'
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install requirements


### PR DESCRIPTION
Fixing the warnings seen on e.g. https://github.com/hiboxsystems/marge-bot/actions/runs/3751396537:

<img width="1418" alt="bild" src="https://user-images.githubusercontent.com/1417619/208970668-375ef453-ea7f-4fa0-afc4-310161ddbc8c.png">
