### PR TITLE
Revert "feat: Skip cloning if using --rebase-remotely (#5)"

### DIFF
--- a/marge/bot.py
+++ b/marge/bot.py
@@ -31,13 +31,11 @@ class Bot:
             )
 
     def start(self):
-        skip_clone = self._config.merge_opts.fusion is Fusion.gitlab_rebase
         with TemporaryDirectory() as root_dir:
             if self._config.use_https:
                 repo_manager = store.HttpsRepoManager(
                     user=self.user,
                     root_dir=root_dir,
-                    skip_clone=skip_clone,
                     auth_token=self._config.auth_token,
                     timeout=self._config.git_timeout,
                     reference=self._config.git_reference_repo,
@@ -46,7 +44,6 @@ class Bot:
                 repo_manager = store.SshRepoManager(
                     user=self.user,
                     root_dir=root_dir,
-                    skip_clone=skip_clone,
                     ssh_key_file=self._config.ssh_key_file,
                     timeout=self._config.git_timeout,
                     reference=self._config.git_reference_repo,

--- a/marge/store.py
+++ b/marge/store.py
@@ -6,11 +6,10 @@ from . import git
 
 class RepoManager:
 
-    def __init__(self, user, root_dir, skip_clone, timeout=None, reference=None):
+    def __init__(self, user, root_dir, timeout=None, reference=None):
         self._root_dir = root_dir
         self._user = user
         self._repos = {}
-        self._skip_clone = skip_clone
         self._timeout = timeout
         self._reference = reference
 
@@ -28,8 +27,8 @@ class RepoManager:
 
 class SshRepoManager(RepoManager):
 
-    def __init__(self, user, root_dir, skip_clone, ssh_key_file=None, timeout=None, reference=None):
-        super().__init__(user, root_dir, skip_clone, timeout, reference)
+    def __init__(self, user, root_dir, ssh_key_file=None, timeout=None, reference=None):
+        super().__init__(user, root_dir, timeout, reference)
         self._ssh_key_file = ssh_key_file
 
     def repo_for_project(self, project):
@@ -40,8 +39,7 @@ class SshRepoManager(RepoManager):
 
             repo = git.Repo(repo_url, local_repo_dir, ssh_key_file=self._ssh_key_file,
                             timeout=self._timeout, reference=self._reference)
-            if not self._skip_clone:
-                repo.clone()
+            repo.clone()
             repo.config_user_info(
                 user_email=self._user.email,
                 user_name=self._user.name,
@@ -58,8 +56,8 @@ class SshRepoManager(RepoManager):
 
 class HttpsRepoManager(RepoManager):
 
-    def __init__(self, user, root_dir, skip_clone, auth_token=None, timeout=None, reference=None):
-        super().__init__(user, root_dir, skip_clone, timeout, reference)
+    def __init__(self, user, root_dir, auth_token=None, timeout=None, reference=None):
+        super().__init__(user, root_dir, timeout, reference)
         self._auth_token = auth_token
 
     def repo_for_project(self, project):
@@ -74,8 +72,7 @@ class HttpsRepoManager(RepoManager):
 
             repo = git.Repo(repo_url, local_repo_dir, ssh_key_file=None,
                             timeout=self._timeout, reference=self._reference)
-            if not self._skip_clone:
-                repo.clone()
+            repo.clone()
             repo.config_user_info(
                 user_email=self._user.email,
                 user_name=self._user.name,

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -19,7 +19,7 @@ class TestRepoManager:
         user = marge.user.User(api=None, info=dict(USER_INFO, name='Peter Parker', email='pparker@bugle.com'))
         self.root_dir = tempfile.TemporaryDirectory()
         self.repo_manager = marge.store.SshRepoManager(
-            user=user, root_dir=self.root_dir.name, skip_clone=False, ssh_key_file='/ssh/key',
+            user=user, root_dir=self.root_dir.name, ssh_key_file='/ssh/key',
         )
 
     def teardown_method(self, _method):


### PR DESCRIPTION
This reverts commit fa770242144301969f4f1e693be9efb310d82c5d.

Turns out this didn't fully work in our context. Trying to fix it in #12, but reverting it for now so we can build a new Marge and start running it.