### PR TITLE
Unbreak `make dockerize` after packages were updated

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,3 +35,9 @@ jobs:
         run: poetry install
       - name: Run tests
         run: poetry run pytest
+  dockerize:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Dockerize
+        run: make dockerize

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.10-slim AS builder
 
 ARG POETRY_VERSION=1.1.15
+RUN pip -V
 RUN pip install poetry==$POETRY_VERSION
 
 WORKDIR /src
@@ -20,7 +21,7 @@ RUN apt-get update && apt-get install -y \
 
 COPY --from=builder /src/requirements.txt /src/dist/marge-*.tar.gz /tmp/
 
-RUN pip install -r /tmp/requirements.txt && \
+RUN pip install --no-deps -r /tmp/requirements.txt && \
   pip install /tmp/marge-*.tar.gz
 
 ENTRYPOINT ["marge"]

--- a/poetry.lock
+++ b/poetry.lock
@@ -602,7 +602,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=4.6)", "pytest-black (
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "ac161880cc5f870e7418eb00ab86b3396d4af5a0a2dc5ec07f28c2e5d0d2001c"
+content-hash = "e5fb3afebb21f03f4478e564951e43262e85e9031d8f302b28d9a24d07b6d54c"
 
 [metadata.files]
 astroid = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ ConfigArgParse = "^1.3"
 maya = "^0.6.1"
 PyYAML = "^5.4.1"
 requests = "^2.25.1"
+tzdata = "^2022.7"
 
 [tool.poetry.dev-dependencies]
 pytest = "~7.0.1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -192,7 +192,7 @@ snaptime==0.2.4 \
 typing-extensions==4.1.1; python_version < "3.8" and python_version >= "3.6" \
     --hash=sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2 \
     --hash=sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42
-tzdata==2022.7; platform_system == "Windows" and python_version >= "3.6" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6") \
+tzdata==2022.7; python_version >= "2" \
     --hash=sha256:2b88858b0e3120792a3c0635c23daf36a7d7eeeca657c323da299d2094402a0d \
     --hash=sha256:fe5f866eddd8b96e9fcba978f8e503c909b19ea7efda11e52e39494bad3a7bfa
 tzlocal==4.2; python_version >= "3.6" \

--- a/requirements_development.txt
+++ b/requirements_development.txt
@@ -371,7 +371,7 @@ typed-ast==1.5.4; implementation_name == "cpython" and python_version < "3.8" an
 typing-extensions==4.1.1; python_version < "3.8" and python_version >= "3.6" \
     --hash=sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2 \
     --hash=sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42
-tzdata==2022.7; platform_system == "Windows" and python_version >= "3.6" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6") \
+tzdata==2022.7; python_version >= "2" \
     --hash=sha256:2b88858b0e3120792a3c0635c23daf36a7d7eeeca657c323da299d2094402a0d \
     --hash=sha256:fe5f866eddd8b96e9fcba978f8e503c909b19ea7efda11e52e39494bad3a7bfa
 tzlocal==4.2; python_version >= "3.6" \


### PR DESCRIPTION
`make dockerize` stopped working after updating package versions in #18:

```
Collecting tzdata
ERROR: In --require-hashes mode, all requirements must have their versions pinned with ==. These do not:
    tzdata from https://files.pythonhosted.org/packages/fa/5e/f99a7df3ae2079211d31ec23b1d34380c7870c26e99159f6e422dcbab538/tzdata-2022.7-py2.py3-none-any.whl (from pytz-deprecation-shim==0.1.0.post0->-r /tmp/requirements.txt (line 70))
The command '/bin/sh -c pip install -r /tmp/requirements.txt &&   pip install /tmp/marge-*.tar.gz' returned a non-zero code: 1
make: *** [Makefile:31: dockerize] Error 1
```

I _think_ the problem is that `tzdata` is somehow needed by some dependency, but isn't listed as a poetry dependency, but installed by "legacy setuptools" as described by https://pip.pypa.io/en/stable/topics/secure-installs/#do-not-use-setuptools-directly. Fixing it by 1) enabling `--no-deps` 2) including `tzdata` as a direct dependency.

A related issue that pointed me in the right direction: https://github.com/pypa/pip/issues/9644