### PR TITLE
Use ci_timeout for merging

### DIFF
--- a/marge/job.py
+++ b/marge/job.py
@@ -22,7 +22,7 @@ class MergeJob:
         self._project = project
         self._repo = repo
         self._options = options
-        self._merge_timeout = timedelta(minutes=5)
+        self._merge_timeout = options.ci_timeout
 
     @property
     def repo(self):


### PR DESCRIPTION
From https://github.com/hiboxsystems/marge-bot/commit/6fd802c4e0ac86bdd5649d1b0259f3434a7deb24

We get a lot of `It is taking too long to see the request marked as merged!`, so would be nice to have this change.