### PR TITLE
Fix discovery of tests in VS Code

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,8 @@ env:
   PY_COLORS: 1
 
 jobs:
-  test:
-    runs-on: ubuntu-20.04
+  lint:
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version:
@@ -22,7 +22,31 @@ jobs:
           - '3.9'
           - '3.10'
         poetry-version:
-          - '1.4.2'
+          - '1.5.1'
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Poetry
+        run: pip install poetry==${{ matrix.poetry-version }}
+      - name: Install requirements
+        run: poetry install
+      - name: Run flake8
+        run: poetry run flake8 marge tests
+      - name: Run pylint
+        run: poetry run pylint marge tests
+  test:
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        python-version:
+          - '3.7'
+          - '3.8'
+          - '3.9'
+          - '3.10'
+        poetry-version:
+          - '1.5.1'
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -35,7 +59,7 @@ jobs:
       - name: Run tests
         run: poetry run pytest
   dockerize:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Dockerize

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,4 +8,5 @@
         "tests",
         "--no-cov"
     ],
+    "python.testing.unittestEnabled": false,
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.10-slim AS builder
 
-ARG POETRY_VERSION=1.4.2
+ARG POETRY_VERSION=1.5.1
 RUN pip -V
 RUN pip install poetry==$POETRY_VERSION
 

--- a/README.md
+++ b/README.md
@@ -409,6 +409,8 @@ automatically restart marge-bot in case of intermittent GitLab problems.
 ### Running linting and tests
 
 ```shell
+poetry run flake8 marge tests
+poetry run pylint marge tests
 poetry run pytest
 ```
 

--- a/pylintrc
+++ b/pylintrc
@@ -1,5 +1,7 @@
 [MASTER]
+ignore-paths=.venv
 persistent=no
+jobs=0
 
 [BASIC]
 include-naming-hint=yes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,5 +29,5 @@ marge = "marge.__main__:run"
 "marge.app" = "marge.__main__:run"
 
 [build-system]
-requires = ["poetry-core>=1.4.0"]
+requires = ["poetry-core>=1.5.0"]
 build-backend = "poetry.core.masonry.api"

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 test=pytest
 
 [tool:pytest]
-addopts = --flake8 --pylint --cov=marge
+addopts = --cov=marge
 testpaths = tests marge
 
 [flake8]


### PR DESCRIPTION
It seems like specifying `addopts` for `pytest` in `setup.cfg` does not play well with VS Code test discovery. With `--flake8 --pylint` set, no test methods or files are detected at all.

This change splits flake8 and pylint from pytest and runs them as separate steps in CI.