### PR TITLE
chore(Dockerfile): missing ssh package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get update -q \
     && apt-get install -yq --no-install-recommends \
     git=1:2.39.2-1.1 \
+    ssh=1:9.2p1-2+deb12u2 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /var/log/*
 


### PR DESCRIPTION
I forgot to add the ssh package when doing the Dockerfile optimisations (required to clone private repositories)