### PR TITLE
Less logging by default

### DIFF
--- a/marge/bot.py
+++ b/marge/bot.py
@@ -129,7 +129,7 @@ class Bot:
         return processed_merge_requests
 
     def _get_merge_requests(self, project, project_name):
-        log.info('Fetching merge requests assigned to me in %s...', project_name)
+        log.debug('Fetching merge requests assigned to me in %s...', project_name)
         my_merge_requests = MergeRequest.fetch_all_open_for_user(
             project_id=project.id,
             user=self.user,


### PR DESCRIPTION
The `Fetching merge requests assigned to me` log row is not very useful in practice, and it just fills the logs.